### PR TITLE
Add file parsing for worldbuilding

### DIFF
--- a/data/entrance-gate-research.toml
+++ b/data/entrance-gate-research.toml
@@ -1,0 +1,6 @@
+name = "Entrance"
+region = "Gate Research"
+description = "Spawn only"
+
+[exits.west]
+room_id = "ramp-gate-research" # Security Stations

--- a/data/ramp-gate-research.toml
+++ b/data/ramp-gate-research.toml
@@ -1,0 +1,23 @@
+name = "Arrival Ramp"
+region = "Gate Research"
+description = """
+It feels like the worst hangover you've ever experienced. Your head is pounding, your stomach is in knots. Slowly, your senses return to you. Your hearing come first. Muffled sirens become deafening.
+
+A loudspeaker slowly becomes intelligable. "Gate active, incoming arrivals!"
+
+You feel like you might be sick as the room spins around you but, slowly, you get to your feet as you feel hands reach out to help. What were white blurs now start to resolve in to people in lab coats. They wrap you in thermal blankets and thrust a bottle in to your hand.
+
+"Take it easy, arrival is nasty business. Drink that, its vitamins and electrolytes. Oh and a mild painkiller, too!" the closest figure says.
+
+As you look more closely, you see the figure helping you up is a dark-haired woman with a namebadge that reads 'Dr. Julia Maggs, Chief Arrivals Officer'.
+
+"Welcome to the new world!" she says, with a wry smile. You feel like she says this a lot and its intended to bring levity to an, otherwise, unpleasant experience. "Don't worry. How you're feeling? That's normal. When you're ready, step down the ramp and follow my colleagues to recovery and orientation."
+
+She leads you to the ramp and goes back to help her colleagues with the other new arrivals. Past Dr. Maggs, you see... something, hanging in the air, a shimmer like a heat haze over a scorched desert. Looking at it makes your headache even worse and seems to cause a ringing in your ears. You quickly look away and make your way down the ramp.
+
+@Welcome to Gleamud, a MUD (multi-user dungeon) created by SoupStoreGames. You need to go through processing. As you do, these hints will appear to guide you through the world and teach you how to play. You move in a direction by typing out that direction, ^north^, ^south^, ^down^, etc. You can also use shorthand for some of these like ^n^ for ^north^. Go down the ramp now to go to the next area.@
+"""
+
+[exits.down]
+region = "Gate Research"
+room = "entrance-gate-research" # Entrance

--- a/gleam.toml
+++ b/gleam.toml
@@ -19,6 +19,8 @@ gleam_otp = "~> 0.10"
 gleam_erlang = "~> 0.24"
 repeatedly = "~> 2.1"
 chromatic = "~> 1.0"
+tom = "~> 0.3"
+simplifile = "~> 1.5"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -9,13 +9,17 @@ packages = [
   { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
   { name = "glisten", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], source = "local", path = "../glisten" },
   { name = "repeatedly", version = "2.1.1", build_tools = ["gleam"], requirements = [], otp_app = "repeatedly", source = "hex", outer_checksum = "38808C3EC382B0CD981336D5879C24ECB37FCB9C1D1BD128F7A80B0F74404D79" },
+  { name = "simplifile", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "EB9AA8E65E5C1E3E0FDCFC81BC363FD433CB122D7D062750FFDF24DE4AC40116" },
+  { name = "tom", version = "0.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "tom", source = "hex", outer_checksum = "0831C73E45405A2153091226BF98FB485ED16376988602CC01A5FD086B82D577" },
 ]
 
 [requirements]
-chromatic = { version = "~> 1.0"}
+chromatic = { version = "~> 1.0" }
 gleam_erlang = { version = "~> 0.24" }
 gleam_otp = { version = "~> 0.10" }
 gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
 gleeunit = { version = "~> 1.0" }
 glisten = { path = "../glisten" }
 repeatedly = { version = "~> 2.1" }
+simplifile = { version = "~> 1.5"}
+tom = { version = "~> 0.3" }

--- a/src/data/world.gleam
+++ b/src/data/world.gleam
@@ -1,5 +1,9 @@
 import gleam/dict.{type Dict}
+import gleam/list
 import gleam/otp/task
+import gleam/string
+import simplifile
+import tom
 import data/core
 
 pub type DataError {
@@ -19,8 +23,12 @@ pub type RegionTemplate {
   RegionTemplate(name: String, rooms: Dict(String, RoomTemplate))
 }
 
-fn add_room(region: RegionTemplate, id: String, room: RoomTemplate) {
-  RegionTemplate(..region, rooms: dict.insert(region.rooms, id, room))
+fn add_room(region: RegionTemplate, room_file: String) {
+  let rooms =
+    parse_room_file("data/" <> room_file <> ".toml")
+    |> dict.insert(region.rooms, room_file, _)
+
+  RegionTemplate(..region, rooms: rooms)
 }
 
 pub type WorldTemplate {
@@ -29,6 +37,78 @@ pub type WorldTemplate {
 
 fn add_region(world: WorldTemplate, id: String, region: RegionTemplate) {
   WorldTemplate(regions: dict.insert(world.regions, id, region))
+}
+
+fn insert_exit(
+  dict: Dict(core.Direction, core.Location),
+  direction: core.Direction,
+  location_result: Result(core.Location, _),
+) {
+  case location_result {
+    Ok(location) -> dict.insert(dict, direction, location)
+    _ -> dict
+  }
+}
+
+fn parse_exit(
+  toml: Dict(String, tom.Toml),
+  keys: List(String),
+) -> Result(core.Location, String) {
+  let region =
+    tom.get_string(
+      toml,
+      keys
+        |> list.append(["region"]),
+    )
+  let room =
+    tom.get_string(
+      toml,
+      keys
+        |> list.append(["room"]),
+    )
+
+  case region, room {
+    Ok(region), Ok(room) -> Ok(core.Location(region, room))
+    _, _ -> Error({ "Could not parse exit for " <> string.concat(keys) })
+  }
+}
+
+fn parse_room_file(file_name: String) -> RoomTemplate {
+  let assert Ok(file_contents) = simplifile.read(from: file_name)
+  let assert Ok(room_data) = tom.parse(file_contents)
+  let assert Ok(name) = tom.get_string(room_data, ["name"])
+  let assert Ok(region) = tom.get_string(room_data, ["region"])
+  let assert Ok(description) = tom.get_string(room_data, ["description"])
+
+  RoomTemplate(
+    region: region,
+    name: name,
+    description: description,
+    exits: dict.new()
+      |> insert_exit(core.North, parse_exit(room_data, ["exits", "north"]))
+      |> insert_exit(core.North, parse_exit(room_data, ["exits", "north"]))
+      |> insert_exit(core.South, parse_exit(room_data, ["exits", "south"]))
+      |> insert_exit(core.East, parse_exit(room_data, ["exits", "east"]))
+      |> insert_exit(core.West, parse_exit(room_data, ["exits", "west"]))
+      |> insert_exit(core.Up, parse_exit(room_data, ["exits", "up"]))
+      |> insert_exit(core.Down, parse_exit(room_data, ["exits", "down"]))
+      |> insert_exit(
+        core.NorthEast,
+        parse_exit(room_data, ["exits", "northeast"]),
+      )
+      |> insert_exit(
+        core.NorthWest,
+        parse_exit(room_data, ["exits", "northwest"]),
+      )
+      |> insert_exit(
+        core.SouthEast,
+        parse_exit(room_data, ["exits", "southeast"]),
+      )
+      |> insert_exit(
+        core.SouthWest,
+        parse_exit(room_data, ["exits", "southwest"]),
+      ),
+  )
 }
 
 pub fn load_world() -> Result(WorldTemplate, DataError) {
@@ -40,15 +120,7 @@ pub fn load_world() -> Result(WorldTemplate, DataError) {
         |> add_region(
           "testregion",
           RegionTemplate(name: "Test Region", rooms: dict.new())
-            |> add_room(
-              "testroom",
-              RoomTemplate(
-                region: "Test Region",
-                name: "Test Room",
-                description: "An empty test room. A black void of nothingness. You get the odd feeling there are actors here, communicating somehow. Some kind of play, perhaps?",
-                exits: dict.new(),
-              ),
-            ),
+            |> add_room("ramp-gate-research"),
         ),
       )
     })

--- a/src/model/simulation.gleam
+++ b/src/model/simulation.gleam
@@ -87,7 +87,7 @@ fn handle_message(
 ) -> actor.Next(SimMessage, SimState) {
   case message {
     Control(JoinAsGuest(update_subject)) -> {
-      let location = core.Location("testregion", "testroom")
+      let location = core.Location("testregion", "ramp-gate-research")
       let entity = dataentity.Entity(0, prefabs.create_guest_player())
       let assert Ok(region_subject) = dict.get(state.regions, location.region)
       process.send(


### PR DESCRIPTION
Adds functions to build templates from toml files, and replaces the default room with the ramp in Gate Research.

Tested locally, was able to parse cleanly.

Out of Scope:
- Exiting cleanly when encountering bad files (if we have bad data we can't start the game anyhow)