### PR TITLE
Add word wrapping at given terminal width

### DIFF
--- a/src/data/world.gleam
+++ b/src/data/world.gleam
@@ -11,8 +11,7 @@ pub fn load_world() -> WorldTemplate {
         RoomTemplate(
           name: "The Testing Room",
           description: "
-In the vast expanse of an empty void, there exists a swirling energy brimming with limitless possibility. Though intangible, its presence is palpable, weaving threads of potentiality that stretch into infinity. 
-Within this ethereal realm, unseen actors move and interact, their forms mere whispers in the cosmic winds. Through the boundless ether, they communicate in a language of energy and intention, exchanging ideas and emotions beyond the constraints of physicality. Each interaction is a dance of creativity and expression, shaping the very fabric of this limitless expanse with their collective consciousness.
+In the vast expanse of an empty void, there exists a swirling energy brimming with limitless possibility. Though intangible, its presence is palpable, weaving threads of potentiality that stretch into infinity. Within this ethereal realm, unseen actors move and interact, their forms mere whispers in the cosmic winds. Through the boundless ether, they communicate in a language of energy and intention, exchanging ideas and emotions beyond the constraints of physicality. Each interaction is a dance of creativity and expression, shaping the very fabric of this limitless expanse with their collective consciousness.
 
 Commands:
 quit         exit the game

--- a/src/data/world.gleam
+++ b/src/data/world.gleam
@@ -11,7 +11,8 @@ pub fn load_world() -> WorldTemplate {
         RoomTemplate(
           name: "The Testing Room",
           description: "
-In the vast expanse of an empty void, there exists a swirling energy brimming with limitless possibility. Though intangible, its presence is palpable, weaving threads of potentiality that stretch into infinity. Within this ethereal realm, unseen actors move and interact, their forms mere whispers in the cosmic winds. Through the boundless ether, they communicate in a language of energy and intention, exchanging ideas and emotions beyond the constraints of physicality. Each interaction is a dance of creativity and expression, shaping the very fabric of this limitless expanse with their collective consciousness.
+In the vast expanse of an empty void, there exists a swirling energy brimming with limitless possibility. Though intangible, its presence is palpable, weaving threads of potentiality that stretch into infinity. 
+Within this ethereal realm, unseen actors move and interact, their forms mere whispers in the cosmic winds. Through the boundless ether, they communicate in a language of energy and intention, exchanging ideas and emotions beyond the constraints of physicality. Each interaction is a dance of creativity and expression, shaping the very fabric of this limitless expanse with their collective consciousness.
 
 Commands:
 quit         exit the game

--- a/src/telnet/render.gleam
+++ b/src/telnet/render.gleam
@@ -180,20 +180,16 @@ fn center(str: String, width: Int) -> String {
     |> result.unwrap(0)
 
   case padding <= 0 {
-    True -> str
+    True ->
+      str
+      |> word_wrap(width)
     False ->
       lines
       |> list.map(fn(str) { string.repeat(" ", padding) <> str })
       |> string.join("\n")
+      |> word_wrap(width)
   }
 }
-
-// fn wrap(str: String, width: Int) -> String {
-//   str
-//   |> string.split("\n")
-//   |> list.fold([], fn(lines, line) { todo })
-//   |> string.join("\n")
-// }
 
 // be sure to call this after wrap
 fn insert_carriage_returns(str: String) -> String {

--- a/src/telnet/render.gleam
+++ b/src/telnet/render.gleam
@@ -27,8 +27,6 @@ const menu_str = "
 
 "
 
-pub const term_width = 80
-
 const escape_re = "\\x1B(?:[@-Z\\\\-_]|\\[[0-?]*[ -/]*[@-~])"
 
 pub fn has_escape_code(input: String) {

--- a/src/telnet/states.gleam
+++ b/src/telnet/states.gleam
@@ -173,17 +173,32 @@ pub fn handle_update(state: State, update: simulation.Update) -> State {
     InWorld(conn, dim, _) -> {
       case update {
         simulation.UpdateRoomDescription(region, name, desc) -> {
-          let assert Ok(_) = render.room_descripion(conn, region, name, desc)
+          let assert Ok(_) =
+            render.room_descripion(
+              state.conn,
+              region,
+              name,
+              desc,
+              state.dimensions.width,
+            )
         }
         simulation.UpdatePlayerSpawned(name) -> {
-          let assert Ok(_) = render.player_spawned(name, conn)
+          let assert Ok(_) =
+            render.erase_line(state.dimensions.width, state.conn)
+          let assert Ok(_) =
+            render.player_spawned(name, state.conn, state.dimensions.width)
         }
         simulation.UpdatePlayerQuit(name) -> {
-          let assert Ok(_) = render.player_quit(name, conn)
+          let assert Ok(_) =
+            render.erase_line(state.dimensions.width, state.conn)
+          let assert Ok(_) =
+            render.player_quit(name, state.conn, state.dimensions.width)
         }
         simulation.UpdateSayRoom(name, text) -> {
-          // let assert Ok(_) = render.erase_line(dim.width, conn)
-          let assert Ok(_) = render.speech(name, text, conn)
+          let assert Ok(_) =
+            render.erase_line(state.dimensions.width, state.conn)
+          let assert Ok(_) =
+            render.speech(name, text, state.conn, state.dimensions.width)
         }
         _ -> Ok(Nil)
       }
@@ -193,19 +208,32 @@ pub fn handle_update(state: State, update: simulation.Update) -> State {
     RoomSay(conn, dim, _) -> {
       case update {
         simulation.UpdateRoomDescription(region, name, desc) -> {
-          let assert Ok(_) = render.room_descripion(conn, region, name, desc)
+          let assert Ok(_) =
+            render.room_descripion(
+              state.conn,
+              region,
+              name,
+              desc,
+              state.dimensions.width,
+            )
         }
         simulation.UpdatePlayerSpawned(name) -> {
-          let assert Ok(_) = render.erase_line(dim.width, conn)
-          let assert Ok(_) = render.player_spawned(name, conn)
+          let assert Ok(_) =
+            render.erase_line(state.dimensions.width, state.conn)
+          let assert Ok(_) =
+            render.player_spawned(name, state.conn, state.dimensions.width)
         }
         simulation.UpdatePlayerQuit(name) -> {
-          let assert Ok(_) = render.erase_line(dim.width, conn)
-          let assert Ok(_) = render.player_quit(name, conn)
+          let assert Ok(_) =
+            render.erase_line(state.dimensions.width, state.conn)
+          let assert Ok(_) =
+            render.player_quit(name, state.conn, state.dimensions.width)
         }
         simulation.UpdateSayRoom(name, text) -> {
-          let assert Ok(_) = render.erase_line(dim.width, conn)
-          let assert Ok(_) = render.speech(name, text, conn)
+          let assert Ok(_) =
+            render.erase_line(state.dimensions.width, state.conn)
+          let assert Ok(_) =
+            render.speech(name, text, state.conn, state.dimensions.width)
         }
         _ -> Ok(Nil)
       }

--- a/test/telnet/render_test.gleam
+++ b/test/telnet/render_test.gleam
@@ -1,0 +1,35 @@
+import gleeunit/should
+import telnet/render.{adjusted_length, has_escape_code, word_wrap}
+
+const str_with_escape = "Type [1mguest[0m to join with a temporary character"
+
+const str_without_escape = "Type guest to join with a temporary character"
+
+const str_wrapped = "Type [1mguest[0m to join with a temporary\ncharacter"
+
+pub fn has_escape_code_test() {
+  let input: String = str_without_escape
+  let result: Bool = has_escape_code(input)
+  result
+  |> should.be_false()
+  let input = str_with_escape
+  let result = has_escape_code(input)
+  result
+  |> should.be_true()
+}
+
+pub fn adjusted_length_test() {
+  let input = str_without_escape
+  let result_wo_esc = adjusted_length(input)
+  let input = str_with_escape
+  let result_w_esc = adjusted_length(input)
+  result_w_esc
+  |> should.equal(result_wo_esc)
+}
+
+pub fn word_wrap_test() {
+  let input = str_wrapped
+  let result = word_wrap(input, 15)
+  result
+  |> should.equal("Type [1mguest[0m to\njoin with a\ntemporary\ncharacter")
+}


### PR DESCRIPTION
This wraps any output to a given terminal width, which is 80 by default. It will also ignore escape secquences, so they don't count towards the length of the current line. NOTE: this will not affect any rendering issues (e.g. extra spaces) caused by using escape sequences, it will only ensure that said escape sequences don't break the word wrapping.